### PR TITLE
feat(ci): validate SonarCloud token presence and skip with clean warning when missing

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -31,6 +31,7 @@ jobs:
             -Dsonar.exclusions=**/coverage/**
             -Dsonar.organization=bcgov-nr
             -Dsonar.projectKey=action-test-and-analyse-java
+          sonar_enforce_compliance: false
           sonar_token: ${{ secrets.SONAR_TOKEN }}
 
       - name: Check triggered output

--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ inputs:
 
   sonar_enforce_compliance:
     description: Fail the build if SonarCloud fails. If false, only warn.
-    default: "false"
+    default: "true"
     pattern: "^(true|false)$"
 
   triggers:

--- a/action.yml
+++ b/action.yml
@@ -119,17 +119,18 @@ runs:
       shell: bash
       run: |
         # Validate SonarCloud Token
-        CLEAN_TOKEN=$(echo "${{ inputs.sonar_token }}" | xargs)
+        TOKEN="${{ inputs.sonar_token }}"
+        TRIMMED="${TOKEN//[[:space:]]/}"
 
-        if [ "$CLEAN_TOKEN" = "__OMITTED__" ]; then
+        if [ "$TRIMMED" = "__OMITTED__" ]; then
           # Intentionally omitted by the user, skip silently without warning
-          echo "run_sonar=false" >> $GITHUB_OUTPUT
-        elif [ -z "$CLEAN_TOKEN" ]; then
+          echo "run_sonar=false" >> "$GITHUB_OUTPUT"
+        elif [ -z "$TRIMMED" ]; then
           # Explicitly provided but resolved to empty string (e.g. empty repository secret)
           echo "::warning title=SonarCloud Skipped::⚠️ SonarCloud token (sonar_token) is missing or empty. Skipping SonarCloud analysis. If you want to enable SonarCloud, ensure the SONAR_TOKEN repository secret is set and passed correctly."
-          echo "run_sonar=false" >> $GITHUB_OUTPUT
+          echo "run_sonar=false" >> "$GITHUB_OUTPUT"
         else
-          echo "run_sonar=true" >> $GITHUB_OUTPUT
+          echo "run_sonar=true" >> "$GITHUB_OUTPUT"
         fi
 
     - if: steps.validate-sonar-token.outputs.run_sonar == 'true' && steps.diff.outputs.triggered == 'true'

--- a/action.yml
+++ b/action.yml
@@ -87,7 +87,7 @@ runs:
       uses: bcgov/action-diff-triggers@4abfcb211f5816d654d1c5a417e5431a2c4a5379 # v1.1.1
       with:
         triggers: ${{ (github.event_name == 'pull_request' && inputs.triggers) || '' }}
-        diff_branch: ${{ inputs.diff_branch }}
+        ref: ${{ inputs.diff_branch }}
 
     - uses: actions/checkout@v6
       with:

--- a/action.yml
+++ b/action.yml
@@ -163,7 +163,7 @@ runs:
         # If SonarCloud failed, handle it based on compliance requirements
         if [ $STATUS -ne 0 ]; then
           if [ "${{ inputs.sonar_enforce_compliance }}" == "true" ]; then
-            echo "::error title=SonarCloud Failed::❌ SonarCloud analysis failed (required by sonar_enforce_compliance). Check token, project configuration, or SonarCloud status."
+            echo "::error title=SonarCloud Failed::❌ SonarCloud analysis failed (sonar_enforce_compliance: true). Check token, project configuration, or SonarCloud status."
             exit 1
           else
             echo "::warning title=SonarCloud Failed::⚠️ SonarCloud analysis failed. This is usually caused by an expired/invalid SONAR_TOKEN, or a missing/stale project on SonarCloud. Since SonarCloud is optional, the build will continue, but you should check your repository secrets and SonarCloud project status."

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,7 @@ inputs:
 
   sonar_token:
     description: Sonar token, provide unpopulated token for pre-setup (will skip)
+    default: "__OMITTED__"
     pattern: "^[a-zA-Z0-9]{20,}$"
 
   triggers:
@@ -120,7 +121,11 @@ runs:
         # Validate SonarCloud Token
         CLEAN_TOKEN=$(echo "${{ inputs.sonar_token }}" | xargs)
 
-        if [ -z "$CLEAN_TOKEN" ]; then
+        if [ "$CLEAN_TOKEN" = "__OMITTED__" ]; then
+          # Intentionally omitted by the user, skip silently without warning
+          echo "run_sonar=false" >> $GITHUB_OUTPUT
+        elif [ -z "$CLEAN_TOKEN" ]; then
+          # Explicitly provided but resolved to empty string (e.g. empty repository secret)
           echo "::warning title=SonarCloud Skipped::⚠️ SonarCloud token (sonar_token) is missing or empty. Skipping SonarCloud analysis. If you want to enable SonarCloud, ensure the SONAR_TOKEN repository secret is set and passed correctly."
           echo "run_sonar=false" >> $GITHUB_OUTPUT
         else

--- a/action.yml
+++ b/action.yml
@@ -141,14 +141,27 @@ runs:
       run: |
         # Run SonarCloud for ${{ inputs.java-cache }}
 
+        # Disable shell failure-on-error so we can catch and handle the exit code
+        set +e
+
         if [ "${{ inputs.java-cache }}" == "maven" ]; then
           mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.host.url=https://sonarcloud.io ${{ inputs.sonar_args }}
+          STATUS=$?
         elif [ "${{ inputs.java-cache }}" == "gradle" ]; then
-          gradlew build sonarqube --info -Dsonar.host.url=https://sonarcloud.io ${{ inputs.sonar_args }}
+          ./gradlew build sonarqube --info -Dsonar.host.url=https://sonarcloud.io ${{ inputs.sonar_args }}
+          STATUS=$?
         else
-          echo "ERROR: inputs.java-cache = ${{ inputs.java-cache }}"
+          echo "::error::ERROR: inputs.java-cache = ${{ inputs.java-cache }}"
           exit 1
         fi
+
+        # If SonarCloud failed, don't fail the build, but inform the developer
+        if [ $STATUS -ne 0 ]; then
+          echo "::warning title=SonarCloud Failed::⚠️ SonarCloud analysis failed. This is usually caused by an expired/invalid SONAR_TOKEN, or a missing/stale project on SonarCloud. Since SonarCloud is optional, the build will continue, but you should check your repository secrets and SonarCloud project status."
+        fi
+
+        # Always return 0 to prevent blocking the pipeline
+        exit 0
 
     ### Cleanup
 

--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,11 @@ inputs:
     default: "__OMITTED__"
     pattern: "^[a-zA-Z0-9]{20,}$"
 
+  sonar_enforce_compliance:
+    description: Fail the build if SonarCloud fails. If false, only warn.
+    default: "false"
+    pattern: "^(true|false)$"
+
   triggers:
     description: Paths (array) used to trigger a build; e.g. ('./backend/' './frontend/)
 
@@ -155,12 +160,17 @@ runs:
           exit 1
         fi
 
-        # If SonarCloud failed, don't fail the build, but inform the developer
+        # If SonarCloud failed, handle it based on compliance requirements
         if [ $STATUS -ne 0 ]; then
-          echo "::warning title=SonarCloud Failed::⚠️ SonarCloud analysis failed. This is usually caused by an expired/invalid SONAR_TOKEN, or a missing/stale project on SonarCloud. Since SonarCloud is optional, the build will continue, but you should check your repository secrets and SonarCloud project status."
+          if [ "${{ inputs.sonar_enforce_compliance }}" == "true" ]; then
+            echo "::error title=SonarCloud Failed::❌ SonarCloud analysis failed (required by sonar_enforce_compliance). Check token, project configuration, or SonarCloud status."
+            exit 1
+          else
+            echo "::warning title=SonarCloud Failed::⚠️ SonarCloud analysis failed. This is usually caused by an expired/invalid SONAR_TOKEN, or a missing/stale project on SonarCloud. Since SonarCloud is optional, the build will continue, but you should check your repository secrets and SonarCloud project status."
+          fi
         fi
 
-        # Always return 0 to prevent blocking the pipeline
+        # Always return 0 to prevent blocking the pipeline for non-blocking fallbacks
         exit 0
 
     ### Cleanup

--- a/action.yml
+++ b/action.yml
@@ -113,7 +113,21 @@ runs:
 
     ### Optional SonarCloud
 
-    - if: inputs.sonar_token && steps.diff.outputs.triggered == 'true'
+    - id: validate-sonar-token
+      if: steps.diff.outputs.triggered == 'true'
+      shell: bash
+      run: |
+        # Validate SonarCloud Token
+        CLEAN_TOKEN=$(echo "${{ inputs.sonar_token }}" | xargs)
+
+        if [ -z "$CLEAN_TOKEN" ]; then
+          echo "::warning title=SonarCloud Skipped::⚠️ SonarCloud token (sonar_token) is missing or empty. Skipping SonarCloud analysis. If you want to enable SonarCloud, ensure the SONAR_TOKEN repository secret is set and passed correctly."
+          echo "run_sonar=false" >> $GITHUB_OUTPUT
+        else
+          echo "run_sonar=true" >> $GITHUB_OUTPUT
+        fi
+
+    - if: steps.validate-sonar-token.outputs.run_sonar == 'true' && steps.diff.outputs.triggered == 'true'
       env:
         SONAR_TOKEN: ${{ inputs.sonar_token }}
       shell: bash


### PR DESCRIPTION
### Discovery & Problem

When GHA composite actions run `secrets.SONAR_TOKEN`, an empty or missing secret evaluates to `""` (an empty string). In GHA expression evaluation, `""` is truthy, which causes GHA to blindly run the `Optional SonarCloud` step anyway. Since it has no token, SonarCloud slams the door shut with a `403 Forbidden` error that obscures the real issue and fails the entire pipeline.

Furthermore, stale projects, deleted project entries, or expired tokens would block everyday developer pipelines with cryptic SonarCloud/API errors.

### Solution

1. **Early Token Validation:** Added a `validate-sonar-token` step in `action.yml` that trims and checks the `sonar_token` input using native shell expansion. If it is empty, it outputs `run_sonar=false` and skips SonarCloud early without wasting build time.
2. **Configurable Compliance Gating (`sonar_enforce_compliance`):**
   * Introduced a new `sonar_enforce_compliance` parameter (defaults to `true`).
   * If SonarCloud fails, the pipeline will **hard-block** by default.
   * If a team explicitly configures `sonar_enforce_compliance: false`, the pipeline catches Sonar failures, emits a high-visibility yellow workflow warning notice, and safely exits `0` so the build can proceed cleanly.
3. **Auditability:** Platform administrators can search the entire GitHub organization for compliance bypasses with:
   `org:bcgov "sonar_enforce_compliance: false"`

This prevents blocking builds on fork PRs or repositories without SonarCloud setups while cleanly keeping developers informed and audited.

Supersedes #46
Closes #46